### PR TITLE
Updates documentation to use correct parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ file should looked like this: ::
     # username = username
     # host = smtp.sample.com
     # password = password
-    # FROM = Cronic <pycronic@sample.com>
+    # from = Cronic <pycronic@sample.com>
     # port = 587
 
 How to use

--- a/README_zh.rst
+++ b/README_zh.rst
@@ -90,7 +90,7 @@ pycronic
     # username = username
     # host = smtp.sample.com
     # password = password
-    # FROM = Cronic <pycronic@sample.com>
+    # from = Cronic <pycronic@sample.com>
     # port = 587
 
 如何使用

--- a/pycronic/constants.py
+++ b/pycronic/constants.py
@@ -20,7 +20,7 @@ mail_title = %s
 # username = username
 # host = smtp.sample.com
 # password = password
-# FROM = Cronic <pycronic@sample.com>
+# from = Cronic <pycronic@sample.com>
 # port = 587
 ''' % (default_mail_title)
 


### PR DESCRIPTION
In order for the `From:` field to be set correctly the documentation has been updated replacing `FROM` with `from` as [per here](https://github.com/piglei/pycronic/blob/master/pycronic/cronic#L38)
