### PR TITLE
Using python Sender library for better smtp tls sending

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,15 +4,15 @@ pycronic
 
 `Chinese Version`_
 
-This project is inspired by `cronic`_ and privided some extra useful functions
-such as sending email error report by SMTP and store logs of crontab scripts.
+This project is inspired by `cronic`_ and includes some extra useful functions
+such as sending email error report through SMTP and store logs of crontab scripts.
 
 Why pycronic?
 =============
 
 Crontab has the ability to send mail notification when any output was generated
-executing your script as we know. And it will send bunch of emails to you 
-every day if your has a lof of scripts, what if we only want to get the mail 
+executing your script, as we know. It will send a bunch of emails to you 
+every day if you have a lof of scripts. What if we only want to get the mail 
 when something goes wrong?
 
 As a result, You may config your crontab like this: ::
@@ -25,12 +25,12 @@ As a result, You may config your crontab like this: ::
     # be notified if your script fails.
     * * * * * some_work > /dev/null 2>&1
 
-Using pycronic to make things simpler: ::
+Using pycronic make things simplier: ::
 
     cronic="/usr/local/bin/cronic"                                                                       
     * * * * * &cronic some_work
 
-All you need is prepend cronic to your script.
+All you need is to prepend cronic to your script execution command.
 **cronic** command will check the return code and the error output for you, if something
 wents wrong, you will get an email notification through crontab's default mailing system
 or your customized STMP server. ::
@@ -58,7 +58,7 @@ or your customized STMP server. ::
 
     Starting backup...
 
-And cronic will stores all your scripts output to a directory(/tmp/pycronic by default).
+And cronic will store all your scripts output to a directory (/tmp/pycronic by default).
 
 Installation
 ============
@@ -67,8 +67,11 @@ Using pip: ::
 
     # Install from pypi
     sudo pip install pycronic
+    # Latest version from git
+    sudo pip install https://github.com/piglei/pycronic/archive/master.zip
     # Or install from github
     sudo pip install -e git+https://github.com/piglei/pycronic/#egg=pycronic
+    
 
 Configuration
 =============
@@ -82,8 +85,8 @@ After the installation, run "cronic" in your command line to verify: ::
     Config file "/etc/pycronic.conf" does not exist!
     Run "cronic init" to create a default one."
 
-Then run "sudo cronic init" to creat a default config file under /etc, the default config
-file should looked like this: ::
+Then run "sudo cronic init" to create a default config file under /etc, the default config
+file should look like this: ::
 
     # Log path for pycronic, pycronic will store all logs to this directory
     log_path = /tmp/pycronic
@@ -108,13 +111,13 @@ file should looked like this: ::
 How to use
 ==========
 
-cronic will be silent if no error has occured when running a script: ::
+cronic will be silent if no error occured when running a script: ::
 
     piglei@macbook-pro:etc$ cronic ls
     piglei@macbook-pro:etc$ cat /tmp/pycronic/ls.log 
     [The script result will be stored in the log file]
 
-But if an error has occured(cronic will check the standard error output), it will print
+But if an error has occured (cronic will check the standard error output), it will print
 an error message like this: ::
 
     $ cronic ls asdf
@@ -137,10 +140,10 @@ an error message like this: ::
 
     None
 
-If you have configured your crontab, now an email will send to your email address.
+If you have configured your crontab an email will send to your email address.
 
-You can also modify config to send mail through smtp instead of using crontab 
-and this is the more recommended.
+You can also modify config to send mail through SMTP instead of using crontab 
+which is highly more recommended.
 
 Rock crontab
 ============

--- a/pycronic/__init__.py
+++ b/pycronic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
 
-__version__ = [0, 0, 2]
+__version__ = [0, 0, 3]
 
 

--- a/pycronic/cronic
+++ b/pycronic/cronic
@@ -7,12 +7,14 @@ import os
 import re
 import sys
 import socket
+import time
 import datetime
 import tempfile
 import traceback
 import subprocess
-import smtplib
-from email.mime.text import MIMEText
+#import smtplib
+#from email.mime.text import MIMEText
+from sender import Mail, Message
 from configobj import ConfigObj
 socket.setdefaulttimeout(60)
 
@@ -28,21 +30,42 @@ class SMTPMailSender(object):
     def __init__(self, config):
         self.config = config
 
-    def send(self, recievers, subject, content):
+    def send(self, receivers, subject, content):
         """
         Send email via SMTP
         """
-        s = smtplib.SMTP(self.config['host'], int(self.config['port']))
-        s.login(self.config['username'], self.config['password'])
+        use_tls = False
+        use_ssl = False
+        smtp_debug_level = None
+        if 'use_tls' in self.config:
+            use_tls = self.config['use_tls']
+        if 'use_ssl' in self.config:
+            use_ssl = self.config['use_ssl']
+        if 'smtp_debug_level' in self.config:
+            smtp_debug_level = self.config['smtp_debug_level']
 
-        from_address = self.config.get('from')
-        for reciever in recievers:
-            msgRoot = MIMEText(content, 'plain', 'UTF-8')
-            msgRoot['Subject'] = subject
-            msgRoot['From'] = from_address
-            msgRoot['To'] = reciever
-            s.sendmail(from_address, reciever, msgRoot.as_string())
-        s.close()
+        s = Mail(self.config['host'], port=int(self.config['port']),\
+            username=self.config['username'], \
+            password=self.config['password'], \
+            use_tls=use_tls, use_ssl=use_ssl, debug_level=smtp_debug_level
+        )
+
+        #s = smtplib.SMTP(self.config['host'], int(self.config['port']))
+        #s.login(self.config['username'], self.config['password'])
+        
+        s.fromadd = self.config.get('from')
+        msg = Message(subject)
+        msg.fromaddr = self.config.get('from')
+        msg.body = content
+        msg.date = time.time()
+        for receiver in receivers:
+            msg.to = receiver
+            #msgRoot = MIMEText(content, 'plain', 'UTF-8')
+            #msgRoot['Subject'] = subject
+            #msgRoot['From'] = from_address
+            #msgRoot['To'] = reciever
+            #s.sendmail(from_address, reciever, msgRoot.as_string())
+            s.send(msg)
 
 
 def main():

--- a/pycronic/cronic
+++ b/pycronic/cronic
@@ -12,8 +12,6 @@ import datetime
 import tempfile
 import traceback
 import subprocess
-#import smtplib
-#from email.mime.text import MIMEText
 from sender import Mail, Message
 from configobj import ConfigObj
 socket.setdefaulttimeout(60)
@@ -50,9 +48,6 @@ class SMTPMailSender(object):
             use_tls=use_tls, use_ssl=use_ssl, debug_level=smtp_debug_level
         )
 
-        #s = smtplib.SMTP(self.config['host'], int(self.config['port']))
-        #s.login(self.config['username'], self.config['password'])
-        
         s.fromadd = self.config.get('from')
         msg = Message(subject)
         msg.fromaddr = self.config.get('from')
@@ -60,11 +55,6 @@ class SMTPMailSender(object):
         msg.date = time.time()
         for receiver in receivers:
             msg.to = receiver
-            #msgRoot = MIMEText(content, 'plain', 'UTF-8')
-            #msgRoot['Subject'] = subject
-            #msgRoot['From'] = from_address
-            #msgRoot['To'] = reciever
-            #s.sendmail(from_address, reciever, msgRoot.as_string())
             s.send(msg)
 
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def readme():
         return f.read()
 
 setup(name='pycronic',
-      version='0.0.2',
+      version='0.0.3',
       description='A crontab script wrapper written by python',
       long_description=readme(),
       author='piglei',
@@ -17,6 +17,7 @@ setup(name='pycronic',
       packages=['pycronic'],
       install_requires=[
           'configobj',
+          'sender',
       ],
       scripts=['pycronic/cronic'],
       zip_safe=False)


### PR DESCRIPTION
Dear piglei,

I found myself adding options for ssl and tls to your pycronic in order to use some SMTP Servers, struggling with "SMTP AUTH not supported by server..." exceptions.

So I replaced plain smtplib with Sender http://sender.readthedocs.io/, a library I am using in other projects and works perfectly well even with Gmail and others.

Sender does not add extra requirements by itself but I will understand if you reject this pull request.

Cheers,
Néstor

Thanks for written pycronic!
