### PR TITLE
Fixes error in python 3.9

### DIFF
--- a/pycronic/cronic
+++ b/pycronic/cronic
@@ -104,7 +104,7 @@ def main():
         ret_code = subprocess.call(command, stdout=stdout, stderr=stderr)
     except OSError as e:
         ret_code = 99
-        stderr.write(traceback.format_exc())
+        stderr.write(traceback.format_exc().encode('utf-8'))
     stdout.seek(0)
     stderr.seek(0)
     stdout_content = stdout.read().strip()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/bin/cronic", line 141, in <module>
    main()
  File "/usr/local/bin/cronic", line 107, in main
    stderr.write(traceback.format_exc())
TypeError: a bytes-like object is required, not 'str'
```